### PR TITLE
deleted reference to entity framework 6

### DIFF
--- a/CactusCare.DAL/CactusCare.DAL.csproj
+++ b/CactusCare.DAL/CactusCare.DAL.csproj
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="EntityFramework" Version="6.3.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.0.1" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="3.0.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This reference is unnecessary. if you experience some issues with enabling migraitons try EntityFrameworkCore/enable-migrations сommand.